### PR TITLE
Feat：add config flag for config file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,6 @@ require (
 	github.com/go-sql-driver/mysql v1.7.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/henrylee2cn/ameda v1.5.1 // indirect
-	github.com/henrylee2cn/goutil v1.0.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/main.go
+++ b/main.go
@@ -3,12 +3,18 @@
 package main
 
 import (
+	"flag"
+
 	"douyin/biz/mw"
 	"douyin/pkg/initialize"
 )
 
 func Init() {
-	initialize.Viper()
+	var config string
+	flag.StringVar(&config, "c", "./pkg/config/config.yml", "-c <config path>")
+	flag.Parse()
+
+	initialize.Viper(config)
 	initialize.MySQL()
 	initialize.Redis()
 	initialize.Global()

--- a/pkg/initialize/viper.go
+++ b/pkg/initialize/viper.go
@@ -8,10 +8,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-func Viper() {
+func Viper(path string) {
 	// 设置配置文件类型和路径
 	viper.SetConfigType("yml")
-	viper.SetConfigFile("./pkg/config/config.yml")
+	viper.SetConfigFile(path)
 	// 读取配置信息
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/tests/benchmark/feed_test.go
+++ b/tests/benchmark/feed_test.go
@@ -1,0 +1,70 @@
+package benchmark
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gm "github.com/onsi/gomega/gmeasure"
+
+	util "douyin/test/testutil"
+)
+
+var _ = Describe("feed test", func() {
+	const (
+		path    = "/douyin/feed"
+		repeats = 1000
+	)
+	var (
+		e *gm.Experiment
+	)
+	BeforeEach(func() {
+		e = gm.NewExperiment("Test Experiment")
+		AddReportEntry(e.Name, e)
+	})
+
+	Context("no token", func() {
+		It("should feed success", func() {
+			e.Sample(func(idx int) {
+				e.MeasureDuration("", func() {
+					resp, err := http.Get(util.CreateURL(path, nil))
+					Expect(err).To(BeNil())
+					defer resp.Body.Close()
+					Expect(resp.StatusCode).To(Equal(200))
+				})
+			}, gm.SamplingConfig{N: repeats})
+		})
+	})
+
+	Context("has token", func() {
+		const (
+			username = "fortest-feed"
+			password = "fortest-feed"
+		)
+
+		var (
+			query = make(map[string]string)
+		)
+
+		BeforeEach(func() {
+			_, token, err := util.GetUseridAndToken(username, password)
+			Expect(err).To(BeNil())
+			query["token"] = token
+		})
+
+		AfterEach(func() {
+			delete(query, "token")
+		})
+
+		It("should feed success", func() {
+			e.Sample(func(idx int) {
+				e.MeasureDuration("", func() {
+					resp, err := http.Get(util.CreateURL(path, query))
+					Expect(err).To(BeNil())
+					defer resp.Body.Close()
+					Expect(resp.StatusCode).To(Equal(200))
+				})
+			}, gm.SamplingConfig{N: repeats})
+		})
+	})
+})

--- a/tests/benchmark/main_test.go
+++ b/tests/benchmark/main_test.go
@@ -1,0 +1,13 @@
+package benchmark
+
+import(
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDouyin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Douyin benchmark test")
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,0 +1,21 @@
+module douyin/test
+
+go 1.19
+
+require (
+	github.com/go-sql-driver/mysql v1.7.1
+	github.com/onsi/ginkgo/v2 v2.11.0
+	github.com/onsi/gomega v1.27.10
+)
+
+require (
+	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
+	golang.org/x/net v0.12.0 // indirect
+	golang.org/x/sys v0.10.0 // indirect
+	golang.org/x/text v0.11.0 // indirect
+	golang.org/x/tools v0.9.3 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/tests/integration/comment_test.go
+++ b/tests/integration/comment_test.go
@@ -1,0 +1,217 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	util "douyin/test/testutil"
+)
+
+var _ = Describe("comment test", func() {
+	const (
+		username = "fortest-comment"
+		password = "fortest-comment"
+		video_id = 2
+		content  = "This is a comment for test"
+	)
+
+	Describe("comment action test", func() {
+		const (
+			path = "/douyin/comment/action"
+		)
+
+		var (
+			query = map[string]string{
+				"video_id": fmt.Sprintf("%d", video_id),
+			}
+			commentId int64
+		)
+
+		BeforeEach(func() {
+			_, token, err := util.GetUseridAndToken(username, password)
+			Expect(err).To(BeNil())
+			query["token"] = token
+		})
+
+		It("should success", func() {
+			before_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 1)
+			query["comment_text"] = content
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentActionResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+			commentId = respData.Comment.ID
+
+			after_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(1))
+		})
+
+		It("should cancel success", func() {
+			before_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(before_cnt > 0).To(BeTrue())
+
+			query["action_type"] = fmt.Sprintf("%d", 2)
+			query["comment_id"] = fmt.Sprintf("%d", commentId)
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentActionResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+
+			after_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(-1))
+		})
+
+		It("wrong token", func() {
+			before_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 1)
+			query["comment_text"] = content
+			query["token"] += "0"
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentActionResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10220)))
+
+			after_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(0))
+		})
+
+		It("wrong video id", func() {
+			before_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 1)
+			query["video_id"] = fmt.Sprintf("%d", -1)
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentActionResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400))) // TODO: better errno
+
+			after_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(0))
+		})
+
+		It("wrong action", func() {
+			before_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 3)
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentActionResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400))) // TODO: better errno
+
+			after_cnt, err := GetCommentNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(0))
+		})
+	})
+
+	Describe("comment list test", func() {
+		const (
+			path = "/douyin/comment/list"
+		)
+
+		var (
+			query = map[string]string{
+				"video_id": fmt.Sprintf("%d", video_id),
+			}
+		)
+
+		BeforeEach(func() {
+			_, token, err := util.GetUseridAndToken(username, password)
+			Expect(err).To(BeNil())
+			query["token"] = token
+		})
+
+		It("should success", func() {
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentListResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("wrong token", func() {
+			query["token"] += "0"
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentListResponse](resp)
+			Expect(err).To(BeNil())
+			// FIXME: wrong token but get comment list success?
+			// Expect(respData.StatusCode).To(Equal(int64(10220)))
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("wrong video id", func() {
+			query["video_id"] = fmt.Sprintf("%d", -1)
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinCommentListResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400))) // TODO: better errno
+		})
+
+		// It("should be in reverse time order", func() {
+		// 	resp, err := http.Get(util.CreateURL(path, query))
+		// 	Expect(err).To(BeNil())
+		// 	Expect(resp.StatusCode).To(Equal(200))
+		// 	respData, err := util.GetDouyinResponse[util.DouyinCommentListResponse](resp)
+		// 	Expect(err).To(BeNil())
+		// 	Expect(respData.StatusCode).To(Equal(int64(0)))
+
+		// 	var lastTime string
+		// 	// lastTime := time.Now()
+		// 	for i, c := range respData.CommentList {
+		// 		t := c.CreateDate
+		// 		Expect(err).To(BeNil())
+		// 		if i > 0 {
+		// 			Expect(t <= lastTime).To(BeTrue())
+		// 		}
+		// 		lastTime = t
+		// 	}
+		// })
+	})
+})
+
+func GetCommentNum(vid int) (num int, err error) {
+	db, err := util.GetDBConnection()
+	if err != nil {
+		return
+	}
+
+	sqlStr := `select comment_count from video where id = ?;`
+	rows, err := db.Query(sqlStr, vid)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	Expect(rows.Next()).To(BeTrue())
+	err = rows.Scan(&num)
+	return
+}

--- a/tests/integration/favorite_test.go
+++ b/tests/integration/favorite_test.go
@@ -1,0 +1,315 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	util "douyin/test/testutil"
+)
+
+var _ = Describe("favorite test", func() {
+	const (
+		username = "fortest-favorite"
+		password = "fortest-favorite"
+	)
+
+	var (
+		query = make(map[string]string)
+	)
+
+	Describe("favorite action test", func() {
+		const (
+			video_id = 1
+			path     = "/douyin/favorite/action"
+		)
+
+		BeforeEach(func() {
+			_, token, err := util.GetUseridAndToken(username, password)
+			Expect(err).To(BeNil())
+			query["token"] = token
+			query["video_id"] = fmt.Sprintf("%d", video_id)
+		})
+
+		It("should success", func() {
+			before_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 1)
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+
+			after_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(1))
+			
+			query["action_type"] = fmt.Sprintf("%d", 2)
+			resp, err = http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err = util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("should cancel success", func() {
+			query["action_type"] = fmt.Sprintf("%d", 1)
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+
+			before_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(before_cnt).NotTo(BeZero())
+
+			query["action_type"] = fmt.Sprintf("%d", 2)
+			resp, err = http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err = util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+
+			after_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(-1))
+		})
+
+		// It("double favorite", func() {
+		// 	before_cnt, err := GetFavoriteNum(video_id)
+		// 	Expect(err).To(BeNil())
+
+		// 	query["action_type"] = fmt.Sprintf("%d", 1)
+		// 	resp, err := http.Post(CreateURL(path+"/action", query), "", nil)
+		// 	Expect(err).To(BeNil())
+		// 	Expect(resp.StatusCode).To(Equal(200))
+		// 	respData, err := GetDouyinResponse[util.DouyinSimpleResponse](resp)
+		// 	Expect(err).To(BeNil())
+		// 	Expect(respData.StatusCode).To(Equal(int64(0)))
+		// 	resp, err = http.Post(CreateURL(path+"/action", query), "", nil)
+		// 	Expect(err).To(BeNil())
+		// 	Expect(resp.StatusCode).To(Equal(200))
+		// 	respData, err = GetDouyinResponse[util.DouyinSimpleResponse](resp)
+		// 	Expect(err).To(BeNil())
+		// 	Expect(respData.StatusCode).To(Equal(int64(0)))
+
+		// 	after_cnt, err := GetFavoriteNum(video_id)
+		// 	Expect(err).To(BeNil())
+		// 	Expect(after_cnt - before_cnt).To(Equal(1))
+
+		// 	// 恢复原来的点赞数据
+		// 	err = RecoverFavoriteData(int(userid), video_id, 1)
+		// 	Expect(err).To(BeNil())
+		// })
+
+		It("wrong token", func() {
+			before_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 1)
+			query["token"] += "0"
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10220)))
+
+			after_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(0))
+		})
+
+		It("wrong video id", func() {
+			before_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 1)
+			query["video_id"] = fmt.Sprintf("%d", -1)
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400))) // TODO: better errno
+
+			after_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(0))
+		})
+
+		It("wrong action", func() {
+			before_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = fmt.Sprintf("%d", 3)
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400))) // TODO: better errno
+
+			after_cnt, err := GetFavoriteNum(video_id)
+			Expect(err).To(BeNil())
+			Expect(after_cnt - before_cnt).To(Equal(0))
+		})
+	})
+
+	Describe("favorite list test", func() {
+		const (
+			path = "/douyin/favorite/list"
+		)
+
+		BeforeEach(func() {
+			userid, token, err := util.GetUseridAndToken(username, password)
+			Expect(err).To(BeNil())
+			query["user_id"] = fmt.Sprintf("%d", userid)
+			query["token"] = token
+		})
+
+		It("should success", func() {
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinFavoriteListResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("should equal 3", func() {
+			err := doFavoriteAction(query["token"])
+			Expect(err).To(BeNil())
+
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinFavoriteListResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+			Expect(len(respData.VideoList)).To(Equal(3))
+
+			err = cancelFavoriteAction(query["token"])
+			Expect(err).To(BeNil())
+		})
+
+		It("wrong token", func() {
+			query["token"] += "0"
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinFavoriteListResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10220)))
+		})
+
+		It("wrong user id", func() {
+			query["user_id"] = "-1"
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinFavoriteListResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400)))
+		})
+
+	})
+})
+
+func GetFavoriteNum(vid int) (num int, err error) {
+	db, err := util.GetDBConnection()
+	if err != nil {
+		return
+	}
+
+	sqlStr := `select favorite_count from video where id = ?;`
+	rows, err := db.Query(sqlStr, vid)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+	Expect(rows.Next()).To(BeTrue())
+	err = rows.Scan(&num)
+	return
+}
+
+func doFavoriteAction(token string) (err error) {
+	q := map[string]string{
+		"token":       token,
+		"video_id":    "1",
+		"action_type": "1",
+	}
+	_, err = http.Post(util.CreateURL("/douyin/favorite/action", q), "", nil)
+	if err != nil {
+		return
+	}
+	q["video_id"] = "2"
+	_, err = http.Post(util.CreateURL("/douyin/favorite/action", q), "", nil)
+	if err != nil {
+		return
+	}
+	q["video_id"] = "3"
+	_, err = http.Post(util.CreateURL("/douyin/favorite/action", q), "", nil)
+	return
+}
+
+func cancelFavoriteAction(token string) (err error) {
+	q := map[string]string{
+		"token":       token,
+		"video_id":    "1",
+		"action_type": "2",
+	}
+	_, err = http.Post(util.CreateURL("/douyin/favorite/action", q), "", nil)
+	if err != nil {
+		return
+	}
+	q["video_id"] = "2"
+	_, err = http.Post(util.CreateURL("/douyin/favorite/action", q), "", nil)
+	if err != nil {
+		return
+	}
+	q["video_id"] = "3"
+	_, err = http.Post(util.CreateURL("/douyin/favorite/action", q), "", nil)
+	return
+}
+
+// func SetFavoriteNum(vid, num int) (err error) {
+// 	db, err := util.GetDBConnection()
+// 	if err != nil {
+// 		return
+// 	}
+
+// 	sqlStr := `update video set favorite_count=? where id = ?;`
+// 	_, err = db.Exec(sqlStr, num, vid)
+// 	return
+// }
+
+// func RecoverFavoriteData(uid, vid, cnt int) (err error) {
+// 	db, err := GetDBConnection()
+// 	if err != nil {
+// 		return
+// 	}
+
+// 	q := `update video set favorite_count=? where id=?`
+// 	_, err = db.Exec(q, cnt, vid)
+// 	if err != nil {
+// 		return
+// 	}
+// 	q = `delete from user_favorite_video where user_id=?;`
+// 	_, err = db.Exec(q, uid)
+// 	if err != nil {
+// 		return
+// 	}
+// 	q = `delete from user where id=?;`
+// 	_, err = db.Exec(q, uid)
+// 	return
+// }

--- a/tests/integration/feed_test.go
+++ b/tests/integration/feed_test.go
@@ -1,0 +1,103 @@
+package integration
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	util "douyin/test/testutil"
+)
+
+var _ = Describe("/douyin/feed api request", func() {
+	const path = "/douyin/feed"
+
+	Context("no token", func() {
+		It("should feed success", func() {
+			resp, err := http.Get(util.CreateURL(path, nil))
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+		})
+
+		It("should less than 30", func() {
+			resp, err := http.Get(util.CreateURL(path, nil))
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinFeedResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(len(respData.VideoList) <= 30).To(BeTrue())
+		})
+
+		// It("should reverse order", func() {
+		// 	resp, err := http.Get(CreateURL(path, nil))
+		// 	Expect(err).To(BeNil())
+		// 	defer resp.Body.Close()
+		// 	Expect(resp.StatusCode).To(Equal(200))
+
+		// 	respData, err := getFeedResponse(resp)
+		// 	Expect(err).To(BeNil())
+		// 	// last := 0
+		// })
+
+		// It("should filter with latest time", func() {
+		// 	resp, err := http.Get(CreateURL(path, nil))
+		// 	Expect(err).To(BeNil())
+		// 	defer resp.Body.Close()
+		// 	Expect(resp.StatusCode).To(Equal(200))
+
+		// 	respData, err := getFeedResponse(resp)
+		// 	latestTime := respData.NextTime
+
+		// 	query := map[string]string{
+		// 		"latest_time": fmt.Sprintf("%d", *latestTime),
+		// 	}
+		// 	resp, err = http.Get(CreateURL(path, query))
+		// 	Expect(err).To(BeNil())
+		// 	defer resp.Body.Close()
+		// 	Expect(resp.StatusCode).To(Equal(200))
+		// 	respData, err = getFeedResponse(resp)
+		// })
+	})
+
+	Context("has token", func() {
+		const (
+			username = "fortest-feed"
+			password = "fortest-feed"
+		)
+
+		var (
+			query = make(map[string]string)
+		)
+
+		BeforeEach(func() {
+			_, token, err := util.GetUseridAndToken(username, password)
+			Expect(err).To(BeNil())
+			query["token"] = token
+		})
+
+		AfterEach(func() {
+			delete(query, "token")
+		})
+
+		It("should feed success", func() {
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+		})
+
+		It("should less than 30", func() {
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinFeedResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(len(respData.VideoList) <= 30).To(BeTrue())
+		})
+	})
+})

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,0 +1,13 @@
+package integration
+
+import(
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDouyin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Douyin integration test")
+}

--- a/tests/integration/message_test.go
+++ b/tests/integration/message_test.go
@@ -1,0 +1,227 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	util "douyin/test/testutil"
+)
+
+var _ = Describe("message test", func() {
+	const (
+		userA = "fortest-message-a"
+		userB = "fortest-message-b"
+	)
+
+	var (
+		idA    int64
+		idB    int64
+		tokenA string
+		tokenB string
+	)
+
+	BeforeEach(func() {
+		var err error
+		idA, tokenA, err = util.GetUseridAndToken(userA, userA)
+		Expect(err).To(BeNil())
+		idB, tokenB, err = util.GetUseridAndToken(userB, userB)
+		Expect(err).To(BeNil())
+		// DoRelationAction(map[string]string{
+		// 	"token":       tokenA,
+		// 	"to_user_id":  fmt.Sprint("%d", idB),
+		// 	"action_type": "1",
+		// })
+		// DoRelationAction(map[string]string{
+		// 	"token":       tokenB,
+		// 	"to_user_id":  fmt.Sprintf("%d", idA),
+		// 	"action_type": "1",
+		// })
+	})
+
+	// AfterEach(func() {
+	// DoRelationAction(map[string]string{
+	// 	"token":       tokenA,
+	// 	"to_user_id":  fmt.Sprint("%d", idB),
+	// 	"action_type": "2",
+	// })
+	// DoRelationAction(map[string]string{
+	// 	"token":       tokenB,
+	// 	"to_user_id":  fmt.Sprintf("%d", idA),
+	// 	"action_type": "2",
+	// })
+	// })
+
+	Describe("message action test", func() {
+		const (
+			path = "/douyin/message/action"
+		)
+
+		var (
+			query = map[string]string{
+				"action_type": "1",
+				"content":     "This is a message for test.",
+			}
+		)
+
+		Context("no friendship", func() {
+			It("should fail", func() {
+				Expect(idB).NotTo(BeZero())
+				query["token"] = tokenA
+				query["to_user_id"] = fmt.Sprintf("%d", idB)
+				resp, err := http.Post(util.CreateURL(path, query), "", nil)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+
+				respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(10400))) // TODO: better error
+			})
+		})
+
+		Context("has friendship", func() {
+			BeforeEach(func() {
+				DoRelationAction(map[string]string{
+					"token":       tokenA,
+					"to_user_id":  fmt.Sprintf("%d", idB),
+					"action_type": "1",
+				})
+				DoRelationAction(map[string]string{
+					"token":       tokenB,
+					"to_user_id":  fmt.Sprintf("%d", idA),
+					"action_type": "1",
+				})
+			})
+
+			AfterEach(func() {
+				DoRelationAction(map[string]string{
+					"token":       tokenA,
+					"to_user_id":  fmt.Sprintf("%d", idB),
+					"action_type": "2",
+				})
+				DoRelationAction(map[string]string{
+					"token":       tokenB,
+					"to_user_id":  fmt.Sprintf("%d", idA),
+					"action_type": "2",
+				})
+			})
+
+			It("A send to B", func() {
+				query["token"] = tokenA
+				query["to_user_id"] = fmt.Sprintf("%d", idB)
+				resp, err := http.Post(util.CreateURL(path, query), "", nil)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+
+				respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+			})
+
+			It("B send to A", func() {
+				query["token"] = tokenB
+				query["to_user_id"] = fmt.Sprintf("%d", idA)
+				resp, err := http.Post(util.CreateURL(path, query), "", nil)
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+
+				respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+			})
+		})
+	})
+
+	Describe("message chat test", func() {
+		const (
+			path = "/douyin/message/chat"
+		)
+
+		var (
+			queryA = make(map[string]string)
+			queryB = make(map[string]string)
+		)
+
+		BeforeEach(func() {
+			queryA["token"] = tokenA
+			queryA["to_user_id"] = fmt.Sprintf("%d", idB)
+			queryB["token"] = tokenB
+			queryB["to_user_id"] = fmt.Sprintf("%d", idA)
+		})
+
+		It("should get message list of A", func() {
+			resp, err := http.Get(util.CreateURL(path, queryA))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinMessageChatResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("should get message list of B", func() {
+			resp, err := http.Get(util.CreateURL(path, queryB))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinMessageChatResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("A should = B", func() {
+			resp, err := http.Get(util.CreateURL(path, queryA))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respDataA, err := util.GetDouyinResponse[util.DouyinMessageChatResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respDataA.StatusCode).To(Equal(int64(0)))
+
+			resp, err = http.Get(util.CreateURL(path, queryB))
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respDataB, err := util.GetDouyinResponse[util.DouyinMessageChatResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respDataB.StatusCode).To(Equal(int64(0)))
+
+			Expect(len(respDataA.MessageList)).To(Equal(len(respDataB.MessageList)))
+		})
+
+		// Context("has friendship", func() {
+		// 	BeforeEach(func() {
+		// 		DoRelationAction(map[string]string{
+		// 			"token":       tokenA,
+		// 			"to_user_id":  fmt.Sprintf("%d", idB),
+		// 			"action_type": "1",
+		// 		})
+		// 		DoRelationAction(map[string]string{
+		// 			"token":       tokenB,
+		// 			"to_user_id":  fmt.Sprintf("%d", idA),
+		// 			"action_type": "1",
+		// 		})
+		// 	})
+
+		// 	AfterEach(func() {
+		// 		DoRelationAction(map[string]string{
+		// 			"token":       tokenA,
+		// 			"to_user_id":  fmt.Sprintf("%d", idB),
+		// 			"action_type": "2",
+		// 		})
+		// 		DoRelationAction(map[string]string{
+		// 			"token":       tokenB,
+		// 			"to_user_id":  fmt.Sprintf("%d", idA),
+		// 			"action_type": "2",
+		// 		})
+		// 	})
+
+		// 	It("should success", func() {
+		// 		resp, err := http.Get(util.CreateURL(path, queryA))
+		// 		Expect(err).To(BeNil())
+		// 		Expect(resp.StatusCode).To(Equal(200))
+		// 		respData, err := util.GetDouyinResponse[util.DouyinMessageChatResponse](resp)
+		// 		Expect(err).To(BeNil())
+		// 		_ = respData
+		// 	})
+		// })
+	})
+})

--- a/tests/integration/relation_test.go
+++ b/tests/integration/relation_test.go
@@ -1,0 +1,507 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	util "douyin/test/testutil"
+)
+
+var _ = Describe("relation test", func() {
+	const (
+		up  = "fortest-up"
+		fan = "fortest-fan"
+	)
+
+	var (
+		upid  int64
+		fanid int64
+	)
+
+	Describe("action test", func() {
+		const (
+			path = "/douyin/relation/action"
+		)
+
+		var (
+			query = make(map[string]string)
+		)
+
+		BeforeEach(func() {
+			fanid_, token, err := util.GetUseridAndToken(fan, fan)
+			Expect(err).To(BeNil())
+			upid_, _, err := util.GetUseridAndToken(up, up)
+			Expect(err).To(BeNil())
+			fanid = fanid_
+			upid = upid_
+			query["token"] = token
+			query["to_user_id"] = fmt.Sprintf("%d", upid)
+		})
+
+		It("should follow success", func() {
+			fansBefore, err := GetFansNum(upid)
+			Expect(err).To(BeNil())
+			upsBefore, err := GetFollowingNum(fanid)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = "1"
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+
+			fansAfter, err := GetFansNum(upid)
+			Expect(err).To(BeNil())
+			Expect(fansAfter - fansBefore).To(Equal(1))
+			upsAfter, err := GetFollowingNum(fanid)
+			Expect(err).To(BeNil())
+			Expect(upsAfter - upsBefore).To(Equal(1))
+
+			// cancel the follow action
+			query["action_type"] = "2"
+			resp, err = http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err = util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("should cancel success", func() {
+			// follow firstly
+			query["action_type"] = "1"
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+
+			fansBefore, err := GetFansNum(upid)
+			Expect(err).To(BeNil())
+			upsBefore, err := GetFollowingNum(fanid)
+			Expect(err).To(BeNil())
+
+			query["action_type"] = "2"
+			resp, err = http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err = util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+
+			fansAfter, err := GetFansNum(upid)
+			Expect(err).To(BeNil())
+			Expect(fansAfter - fansBefore).To(Equal(-1))
+			upsAfter, err := GetFollowingNum(fanid)
+			Expect(err).To(BeNil())
+			Expect(upsAfter - upsBefore).To(Equal(-1))
+		})
+
+		It("wrong token", func() {
+			query["action_type"] = "1"
+			query["token"] += "0"
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10220)))
+		})
+	})
+
+	Describe("follow list test", func() {
+		const (
+			path = "/douyin/relation/follow/list"
+		)
+
+		var (
+			query = make(map[string]string)
+		)
+
+		BeforeEach(func() {
+			id, token, err := util.GetUseridAndToken(fan, fan)
+			Expect(err).To(BeNil())
+			query["user_id"] = fmt.Sprintf("%d", id)
+			query["token"] = token
+		})
+
+		Context("no following", func() {
+			It("should get following list", func() {
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFollowListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+
+				cnt, err := GetFollowingNum(fanid)
+				Expect(err).To(BeNil())
+				for _, u := range respData.UserList {
+					if u.IsFollow {
+						cnt--
+					}
+				}
+				Expect(cnt).To(BeZero())
+			})
+
+			It("wrong token", func() {
+				query["token"] += "0"
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(10220)))
+			})
+		})
+
+		Context("has following", func() {
+			BeforeEach(func() {
+				err := actionFollowing(query["token"], "1")
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				err := actionFollowing(query["token"], "2")
+				Expect(err).To(BeNil())
+			})
+
+			It("should get following list", func() {
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFollowListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+
+				cnt, err := GetFollowingNum(fanid)
+				Expect(err).To(BeNil())
+				for _, u := range respData.UserList {
+					if u.IsFollow {
+						cnt--
+					}
+				}
+				Expect(cnt).To(BeZero())
+			})
+
+			It("wrong token", func() {
+				query["token"] += "0"
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(10220)))
+			})
+		})
+	})
+
+	Describe("follower list test", func() {
+		const (
+			path = "/douyin/relation/follower/list"
+		)
+
+		var (
+			query = make(map[string]string)
+		)
+
+		BeforeEach(func() {
+			id, token, err := util.GetUseridAndToken(up, up)
+			Expect(err).To(BeNil())
+			query["user_id"] = fmt.Sprintf("%d", id)
+			query["token"] = token
+		})
+
+		Context("no follower", func() {
+			It("should get follower list", func() {
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFollowListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+
+				cnt, err := GetFollowerNum(upid)
+				Expect(err).To(BeNil())
+				for _, u := range respData.UserList {
+					if u.IsFollow {
+						cnt--
+					}
+				}
+				Expect(cnt).To(BeZero())
+			})
+
+			It("wrong token", func() {
+				query["token"] += "0"
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(10220)))
+			})
+		})
+
+		Context("has follower", func() {
+			BeforeEach(func() {
+				err := actionFollower(upid, "1")
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				err := actionFollower(upid, "2")
+				Expect(err).To(BeNil())
+			})
+
+			It("should get follower list", func() {
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFollowListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+
+				cnt, err := GetFollowerNum(upid)
+				Expect(err).To(BeNil())
+				for _, u := range respData.UserList {
+					if u.IsFollow {
+						cnt--
+					}
+				}
+				Expect(cnt).To(BeZero())
+			})
+
+			It("wrong token", func() {
+				query["token"] += "0"
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(10220)))
+			})
+		})
+
+	})
+
+	Describe("friend list test", func() {
+		const (
+			path = "/douyin/relation/friend/list"
+		)
+
+		Context("no friendship", func() {
+			var (
+				query = make(map[string]string)
+			)
+
+			BeforeEach(func() {
+				id, token, err := util.GetUseridAndToken(up, up)
+				Expect(err).To(BeNil())
+				query["user_id"] = fmt.Sprintf("%d", id)
+				query["token"] = token
+			})
+
+			It("should fail", func() {
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFriendListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+
+				cnt, err := GetFollowerNum(upid)
+				Expect(cnt).To(BeZero())
+				Expect(err).To(BeNil())
+				for _, u := range respData.UserList {
+					if u.IsFollow {
+						cnt--
+					}
+				}
+				Expect(cnt).To(BeZero())
+			})
+
+			It("wrong token", func() {
+				query["token"] += "0"
+				resp, err := http.Get(util.CreateURL(path, query))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFriendListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(10220)))
+			})
+		})
+
+		Context("has friendship", func() {
+			var (
+				queryA = make(map[string]string)
+				queryB = make(map[string]string)
+			)
+
+			BeforeEach(func() {
+				id, token, err := util.GetUseridAndToken(up, up)
+				Expect(err).To(BeNil())
+				queryA["user_id"] = fmt.Sprintf("%d", id)
+				queryA["token"] = token
+
+				id, token, err = util.GetUseridAndToken(fan, fan)
+				Expect(err).To(BeNil())
+				queryB["user_id"] = fmt.Sprintf("%d", id)
+				queryB["token"] = token
+
+				DoRelationAction(map[string]string{
+					"token":       queryA["token"],
+					"to_user_id":  queryB["user_id"],
+					"action_type": "1",
+				})
+				DoRelationAction(map[string]string{
+					"token":       queryB["token"],
+					"to_user_id":  queryA["user_id"],
+					"action_type": "1",
+				})
+			})
+
+			AfterEach(func() {
+				DoRelationAction(map[string]string{
+					"token":       queryA["token"],
+					"to_user_id":  queryB["user_id"],
+					"action_type": "2",
+				})
+				DoRelationAction(map[string]string{
+					"token":       queryB["token"],
+					"to_user_id":  queryA["user_id"],
+					"action_type": "2",
+				})
+			})
+
+			It("should get friend list of A", func() {
+				resp, err := http.Get(util.CreateURL(path, queryA))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFriendListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+				Expect(respData.UserList[0].Name).To(Equal(fan))
+			})
+
+			It("should get friend list of B", func() {
+				resp, err := http.Get(util.CreateURL(path, queryB))
+				Expect(err).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(200))
+				respData, err := util.GetDouyinResponse[util.DouyinRelationFriendListResponse](resp)
+				Expect(err).To(BeNil())
+				Expect(respData.StatusCode).To(Equal(int64(0)))
+				Expect(respData.UserList[0].Name).To(Equal(up))
+			})
+
+			// It("wrong token", func() {
+			// 	query["token"] += "0"
+			// 	resp, err := http.Get(util.CreateURL(path, query))
+			// 	Expect(err).To(BeNil())
+			// 	Expect(resp.StatusCode).To(Equal(200))
+			// 	respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+			// 	Expect(err).To(BeNil())
+			// 	Expect(respData.StatusCode).To(Equal(int64(10220)))
+			// })
+		})
+
+	})
+})
+
+func DoRelationAction(q map[string]string) {
+	resp, err := http.Post(util.CreateURL("/douyin/relation/action", q), "", nil)
+	Expect(err).To(BeNil())
+	Expect(resp.StatusCode).To(Equal(200))
+	respData, err := util.GetDouyinResponse[util.DouyinSimpleResponse](resp)
+	Expect(err).To(BeNil())
+	Expect(respData.StatusCode).To(Equal(int64(0)))
+}
+
+func GetFansNum(id int64) (res int, err error) {
+	db, err := util.GetDBConnection()
+	if err != nil {
+		return
+	}
+
+	q := `select follower_count from user where id = ?`
+	rows, err := db.Query(q, id)
+	if err != nil {
+		return
+	}
+	rows.Next()
+	err = rows.Scan(&res)
+	return
+}
+
+func GetFollowingNum(id int64) (res int, err error) {
+	db, err := util.GetDBConnection()
+	if err != nil {
+		return
+	}
+
+	q := `select following_count from user where id = ?`
+	rows, err := db.Query(q, id)
+	if err != nil {
+		return
+	}
+	rows.Next()
+	err = rows.Scan(&res)
+	return
+}
+
+func GetFollowerNum(id int64) (res int, err error) {
+	db, err := util.GetDBConnection()
+	if err != nil {
+		return
+	}
+
+	q := `select follower_count from user where id = ?`
+	rows, err := db.Query(q, id)
+	if err != nil {
+		return
+	}
+	rows.Next()
+	err = rows.Scan(&res)
+	return
+}
+
+func actionFollowing(token, action string) (err error) {
+	query := map[string]string{
+		"token":       token,
+		"action_type": action,
+	}
+	for i := 1; i <= 10; i++ {
+		query["to_user_id"] = fmt.Sprintf("%d", i)
+		_, err = http.Post(util.CreateURL("/douyin/relation/action", query), "", nil)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func actionFollower(upid int64, action string) error {
+	const user = "fortest-fans"
+	query := map[string]string{
+		"to_user_id":  fmt.Sprintf("%d", upid),
+		"action_type": action,
+	}
+	for i := 0; i < 10; i++ {
+		f := user + fmt.Sprintf("%d", i)
+		_, token, err := util.GetUseridAndToken(f, f)
+		if err != nil {
+			return err
+		}
+		query["token"] = token
+		_, err = http.Post(util.CreateURL("/douyin/relation/action", query), "", nil)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tests/integration/user_test.go
+++ b/tests/integration/user_test.go
@@ -1,0 +1,246 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	_ "github.com/go-sql-driver/mysql"
+
+	util "douyin/test/testutil"
+)
+
+var _ = Describe("user test", func() {
+	const uPath = "/douyin/user"
+
+	Describe("register test", func() {
+		const (
+			path     = uPath + "/register"
+			testuser = "fortest-register"
+		)
+
+		It("should register success", func() {
+			query := map[string]string{
+				"username": testuser,
+				"password": "123456",
+			}
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserRegisterResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+		})
+
+		It("username exited", func() {
+			query := map[string]string{
+				"username": testuser,
+				"password": "123456",
+			}
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserRegisterResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10111)))
+
+			err = util.DeleteUser(testuser)
+			Expect(err).To(BeNil())
+		})
+
+		It("username too long", func() {
+			longuser := "1111111111111111111111111111111111"
+			Expect(len(longuser) > 32).To(BeTrue())
+			query := map[string]string{
+				"username": longuser,
+				"password": "000000",
+			}
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserRegisterResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400))) // TODO: improve errno
+		})
+
+		It("password too long", func() {
+			longpasswd := "1111111111111111111111111111111111"
+			Expect(len(longpasswd) > 32).To(BeTrue())
+			query := map[string]string{
+				"username": "fortest",
+				"password": longpasswd,
+			}
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserRegisterResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10400)))
+		})
+
+		// TODO: password too short and not strong enough
+	})
+
+	Describe("login test", func() {
+		const (
+			path     = uPath + "/login"
+			username = "fortest-login"
+			password = "fortest-login"
+		)
+		var (
+			userid int64
+			// token  string
+		)
+
+		BeforeEach(func() {
+			var err error
+			userid, _, err = util.GetUseridAndToken(username, password)
+			Expect(err).To(BeNil())
+		})
+
+		It("should login success", func() {
+			query := map[string]string{
+				"username": username,
+				"password": password,
+			}
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserLoginResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+			Expect(respData.UserID).To(Equal(userid))
+			// Expect(respData.Token).To(Equal(token))
+		})
+
+		It("username not exist", func() {
+			user := "user-not-exist"
+			err := util.DeleteUser(user)
+			Expect(err).To(BeNil())
+
+			query := map[string]string{
+				"username": user,
+				"password": "hhhhhh",
+			}
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserLoginResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10201)))
+		})
+
+		It("wrong password", func() {
+			query := map[string]string{
+				"username": username,
+				"password": password + "0",
+			}
+			resp, err := http.Post(util.CreateURL(path, query), "", nil)
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserLoginResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10210)))
+		})
+	})
+
+	Describe("get info test", func() {
+		const (
+			path     = uPath
+			username = "fortest-userinfo"
+		)
+		var (
+			id     int64
+			userid string
+			token  string
+		)
+
+		BeforeEach(func() {
+			var err error
+			id, token, err = util.GetUseridAndToken(username, username)
+			Expect(err).To(BeNil())
+			userid = fmt.Sprintf("%d", id)
+		})
+
+		It("should get info", func() {
+			query := map[string]string{
+				"user_id": userid,
+				"token":   token,
+			}
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(0)))
+			Expect(respData.User.ID).To(Equal(id))
+			Expect(respData.User.Name).To(Equal(username))
+		})
+
+		// It("user_id not exist", func() {
+		// 	err := util.DeleteUser(username)
+		// 	Expect(err).To(BeNil())
+
+		// 	query := map[string]string{
+		// 		"user_id": userid,
+		// 		"token":   token,
+		// 	}
+		// 	resp, err := http.Get(util.CreateURL(path, query))
+		// 	Expect(err).To(BeNil())
+		// 	defer resp.Body.Close()
+		// 	Expect(resp.StatusCode).To(Equal(200))
+
+		// 	respData, err := util.GetDouyinResponse[util.DouyinUserResponse](resp)
+		// 	Expect(err).To(BeNil())
+		// 	Expect(respData.StatusCode).To(Equal(int64(20000)))
+		// })
+
+		It("wrong userid", func() {
+			query := map[string]string{
+				"user_id": userid + "0",
+				"token":   token,
+			}
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(20000)))
+		})
+
+		It("wrong token", func() {
+			query := map[string]string{
+				"user_id": userid,
+				"token":   token + "0",
+			}
+			resp, err := http.Get(util.CreateURL(path, query))
+			Expect(err).To(BeNil())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			respData, err := util.GetDouyinResponse[util.DouyinUserResponse](resp)
+			Expect(err).To(BeNil())
+			Expect(respData.StatusCode).To(Equal(int64(10220)))
+		})
+	})
+
+})

--- a/tests/start_douyin.sh
+++ b/tests/start_douyin.sh
@@ -1,0 +1,1 @@
+cd .. && nohup go run .&

--- a/tests/test_config.yml
+++ b/tests/test_config.yml
@@ -1,0 +1,37 @@
+hertz:
+  host: 127.0.0.1
+  port: 30000
+
+jwt:
+  signingKey: CloudWeRun
+  identityKey: id
+
+mysql:
+  host: 127.0.0.1
+  port: 3306
+  username: longfar 
+  password: Ning
+  dbName: douyin_test
+  maxOpenConn: 100
+  maxIdleConn: 10
+
+videoCRCRedis:
+  host: localhost
+  port: 6379
+  password:
+  db: 0
+  poolSize: 100
+
+videoFRCRedis:
+  host: localhost
+  port: 6379
+  password:
+  db: 1
+  poolSize: 100
+
+userInfoRCRedis:
+  host: localhost
+  port: 6379
+  password:
+  db: 2
+  poolSize: 100

--- a/tests/testutil/model.go
+++ b/tests/testutil/model.go
@@ -1,0 +1,149 @@
+package testutil
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func GetDouyinResponse[T any](resp *http.Response) (respData T, err error) {
+	var data []byte
+	if data, err = io.ReadAll(resp.Body); err == nil {
+		err = json.Unmarshal(data, &respData)
+	}
+	return
+}
+
+type UserInfo struct {
+	ID              int64  `thrift:"id,1,required" form:"id,required" json:"id,required" query:"id,required"`
+	Name            string `thrift:"name,2,required" form:"name,required" json:"name,required" query:"name,required"`
+	FollowCount     int64  `thrift:"follow_count,3,required" form:"follow_count,required" json:"follow_count,required" query:"follow_count,required"`
+	FollowerCount   int64  `thrift:"follower_count,4,required" form:"follower_count,required" json:"follower_count,required" query:"follower_count,required"`
+	IsFollow        bool   `thrift:"is_follow,5,required" form:"is_follow,required" json:"is_follow,required" query:"is_follow,required"`
+	Avatar          string `thrift:"avatar,6,required" form:"avatar,required" json:"avatar,required" query:"avatar,required"`
+	BackgroundImage string `thrift:"background_image,7,required" form:"background_image,required" json:"background_image,required" query:"background_image,required"`
+	Signature       string `thrift:"signature,8,required" form:"signature,required" json:"signature,required" query:"signature,required"`
+	TotalFavorited  int64  `thrift:"total_favorited,9,required" form:"total_favorited,required" json:"total_favorited,required" query:"total_favorited,required"`
+	WorkCount       int64  `thrift:"work_count,10,required" form:"work_count,required" json:"work_count,required" query:"work_count,required"`
+	FavoriteCount   int64  `thrift:"favorite_count,11,required" form:"favorite_count,required" json:"favorite_count,required" query:"favorite_count,required"`
+}
+
+type Video struct {
+	ID            int64     `thrift:"id,1,required" form:"id,required" json:"id,required" query:"id,required"`
+	Author        *UserInfo `thrift:"author,2,required" form:"author,required" json:"author,required" query:"author,required"`
+	PlayURL       string    `thrift:"play_url,3,required" form:"play_url,required" json:"play_url,required" query:"play_url,required"`
+	CoverURL      string    `thrift:"cover_url,4,required" form:"cover_url,required" json:"cover_url,required" query:"cover_url,required"`
+	FavoriteCount int64     `thrift:"favorite_count,5,required" form:"favorite_count,required" json:"favorite_count,required" query:"favorite_count,required"`
+	CommentCount  int64     `thrift:"comment_count,6,required" form:"comment_count,required" json:"comment_count,required" query:"comment_count,required"`
+	IsFavorite    bool      `thrift:"is_favorite,7,required" form:"is_favorite,required" json:"is_favorite,required" query:"is_favorite,required"`
+	Title         string    `thrift:"title,8,required" form:"title,required" json:"title,required" query:"title,required"`
+}
+
+type DouyinFeedResponse struct {
+	StatusCode int64    `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string  `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	VideoList  []*Video `thrift:"video_list,3" form:"video_list" json:"video_list" query:"video_list"`
+	NextTime   *int64   `thrift:"next_time,4,optional" form:"next_time" json:"next_time,omitempty" query:"next_time"`
+}
+
+type DouyinUserRegisterResponse struct {
+	StatusCode int64   `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	UserID     int64   `thrift:"user_id,3,required" form:"user_id,required" json:"user_id,required" query:"user_id,required"`
+	Token      string  `thrift:"token,4,required" form:"token,required" json:"token,required" query:"token,required"`
+}
+
+type DouyinUserLoginResponse struct {
+	StatusCode int64   `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	UserID     int64   `thrift:"user_id,3,required" form:"user_id,required" json:"user_id,required" query:"user_id,required"`
+	Token      string  `thrift:"token,4,required" form:"token,required" json:"token,required" query:"token,required"`
+}
+
+type DouyinUserResponse struct {
+	StatusCode int64     `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string   `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	User       *UserInfo `thrift:"user,3,required" form:"user,required" json:"user,required" query:"user,required"`
+}
+
+// type DouyinPublishListResponse struct {
+// 	StatusCode int64    `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+// 	StatusMsg  *string  `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+// 	VideoList  []*Video `thrift:"video_list,3" form:"video_list" json:"video_list" query:"video_list"`
+// }
+
+type DouyinSimpleResponse struct {
+	StatusCode int64   `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+}
+
+type User struct {
+	ID            int64  `thrift:"id,1,required" form:"id,required" json:"id,required" query:"id,required"`
+	Name          string `thrift:"name,2,required" form:"name,required" json:"name,required" query:"name,required"`
+	FollowCount   *int64 `thrift:"follow_count,3,optional" form:"follow_count" json:"follow_count,omitempty" query:"follow_count"`
+	FollowerCount *int64 `thrift:"follower_count,4,optional" form:"follower_count" json:"follower_count,omitempty" query:"follower_count"`
+	IsFollow      bool   `thrift:"is_follow,5,required" form:"is_follow,required" json:"is_follow,required" query:"is_follow,required"`
+	Avatar        string `thrift:"avatar,6,required" form:"avatar,required" json:"avatar,required" query:"avatar,required"`
+}
+
+type Comment struct {
+	ID         int64  `thrift:"id,1,required" form:"id,required" json:"id,required" query:"id,required"`
+	User       *User  `thrift:"user,2,required" form:"user,required" json:"user,required" query:"user,required"`
+	Content    string `thrift:"content,3,required" form:"content,required" json:"content,required" query:"content,required"`
+	CreateDate string `thrift:"create_date,4,required" form:"create_date,required" json:"create_date,required" query:"create_date,required"`
+}
+
+type DouyinCommentActionResponse struct {
+	StatusCode int64    `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string  `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	Comment    *Comment `thrift:"comment,3,optional" form:"comment" json:"comment,omitempty" query:"comment"`
+}
+
+type DouyinCommentListResponse struct {
+	StatusCode  int64      `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg   *string    `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	CommentList []*Comment `thrift:"comment_list,3" form:"comment_list" json:"comment_list" query:"comment_list"`
+}
+
+type DouyinFavoriteListResponse struct {
+	StatusCode int64    `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string  `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	VideoList  []*Video `thrift:"video_list,3" form:"video_list" json:"video_list" query:"video_list"`
+}
+
+type DouyinRelationFollowListResponse struct {
+	StatusCode int64   `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	UserList   []*User `thrift:"user_list,3" form:"user_list" json:"user_list" query:"user_list"`
+}
+
+type FriendUser struct {
+	ID            int64   `thrift:"id,1,required" form:"id,required" json:"id,required" query:"id,required"`
+	Name          string  `thrift:"name,2,required" form:"name,required" json:"name,required" query:"name,required"`
+	FollowCount   *int64  `thrift:"follow_count,3,optional" form:"follow_count" json:"follow_count,omitempty" query:"follow_count"`
+	FollowerCount *int64  `thrift:"follower_count,4,optional" form:"follower_count" json:"follower_count,omitempty" query:"follower_count"`
+	IsFollow      bool    `thrift:"is_follow,5,required" form:"is_follow,required" json:"is_follow,required" query:"is_follow,required"`
+	Avatar        string  `thrift:"avatar,6,required" form:"avatar,required" json:"avatar,required" query:"avatar,required"`
+	Message       *string `thrift:"message,7,optional" form:"message" json:"message,omitempty" query:"message"`
+	MsgType       int8    `thrift:"msgType,8,required" form:"msgType,required" json:"msgType,required" query:"msgType,required"`
+}
+
+type DouyinRelationFriendListResponse struct {
+	StatusCode int64         `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg  *string       `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	UserList   []*FriendUser `thrift:"user_list,3" form:"user_list" json:"user_list" query:"user_list"`
+}
+
+type DouyinMessageChatResponse struct {
+	StatusCode  int64      `thrift:"status_code,1,required" form:"status_code,required" json:"status_code,required" query:"status_code,required"`
+	StatusMsg   *string    `thrift:"status_msg,2,optional" form:"status_msg" json:"status_msg,omitempty" query:"status_msg"`
+	MessageList []*Message `thrift:"message_list,3" form:"message_list" json:"message_list" query:"message_list"`
+}
+
+type Message struct {
+	ID         int64  `thrift:"id,1,required" form:"id,required" json:"id,required" query:"id,required"`
+	ToUserID   int64  `thrift:"to_user_id,2,required" form:"to_user_id,required" json:"to_user_id,required" query:"to_user_id,required"`
+	FromUserID int64  `thrift:"from_user_id,3,required" form:"from_user_id,required" json:"from_user_id,required" query:"from_user_id,required"`
+	Content    string `thrift:"content,4,required" form:"content,required" json:"content,required" query:"content,required"`
+	CreateTime *int64 `thrift:"create_time,5,optional" form:"create_time" json:"create_time,omitempty" query:"create_time"`
+}

--- a/tests/testutil/testutil.go
+++ b/tests/testutil/testutil.go
@@ -1,0 +1,90 @@
+package testutil
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+const ROOT = "http://127.0.0.1:30000"
+
+func CreateURL(path string, query map[string]string) (res string) {
+	res = ROOT + path
+	if len(query) > 0 {
+		res += "?"
+		for k, v := range query {
+			res += k + "=" + v + "&"
+		}
+		res = res[:len(res)-1]
+	}
+	return
+}
+
+func GetDBConnection() (db *sql.DB, err error) {
+	db, err = sql.Open("mysql", "longfar:Ning@tcp(127.0.0.1:3306)/douyin")
+	if err != nil {
+		return
+	}
+	err = db.Ping()
+	return
+}
+
+func CreateUser(username, password string) (userid int64, token string, err error) {
+	query := map[string]string{
+		"username": username,
+		"password": password,
+	}
+	resp, err := http.Post(CreateURL("/douyin/user/register", query), "", nil)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	respData, err := GetDouyinResponse[DouyinUserRegisterResponse](resp)
+	if err != nil {
+		return
+	}
+	return respData.UserID, respData.Token, nil
+}
+
+func DeleteUser(username string) (err error) {
+	db, err := GetDBConnection()
+	if err != nil {
+		return
+	}
+	defer db.Close()
+
+	strDel := "delete from user where username = ?"
+	_, err = db.Exec(strDel, username)
+	return err
+}
+
+func GetUseridAndToken(username, password string) (userid int64, token string, err error) {
+	query := map[string]string{
+		"username": username,
+		"password": password,
+	}
+	resp, err := http.Post(CreateURL("/douyin/user/register", query), "", nil)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	respData, err := GetDouyinResponse[DouyinUserRegisterResponse](resp)
+	if err != nil {
+		return
+	} else if respData.StatusCode == 10111 {
+		resp, err = http.Post(CreateURL("/douyin/user/login", query), "", nil)
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+
+		var respData DouyinUserLoginResponse
+		respData, err = GetDouyinResponse[DouyinUserLoginResponse](resp)
+		if err != nil {
+			return
+		}
+		return respData.UserID, respData.Token, nil
+	}
+	return respData.UserID, respData.Token, nil
+}


### PR DESCRIPTION
建议运行测试采用单独的数据库，这就需要修改配置文件，于是测试和运行就要改来改去。
因此建议采用命令行参数形式指定配置文件路径，默认是原来的。这部分更改就增加了这一个小功能和一个测试配置文件。